### PR TITLE
remove errno and elog in signal handler

### DIFF
--- a/pg_onnx/bridge/bgworker_side/bgworker.cpp
+++ b/pg_onnx/bridge/bgworker_side/bgworker.cpp
@@ -45,6 +45,12 @@ int bgworker_init(extension_state_t *state, volatile sig_atomic_t *terminated) {
 			elog(LOG, "Got latch event: WL_POSTMASTER_DEATH");
 			*terminated = true;
 		}
+
+		if (*terminated) {
+			elog(WARNING, "Background worker got SIGTERM");
+			int save_errno = errno;
+			errno = save_errno;
+		}
 	}
 
 	server_thread.join();

--- a/pg_onnx/pg_background_worker.cpp
+++ b/pg_onnx/pg_background_worker.cpp
@@ -114,12 +114,9 @@ void _PG_fini(void) {
 }
 
 static void worker_sigterm(SIGNAL_ARGS) {
-	elog(WARNING, "Background worker got SIGTERM");
-	int save_errno = errno;
 	terminated = true;
 	if (MyProc)
 		SetLatch(&MyProc->procLatch);
-	errno = save_errno;
 }
 
 void worker_exit(extension_state_t *state, int code) {


### PR DESCRIPTION
Operations being performed separately are interrupted by interrupts from the signal handler. To avoid this interference, remove the elog and non-volatile variable (errno) in the signal handler and operate it in the main loop.