### PR TITLE
Add optional JSONB option (ortextensions_path) to pg_onnx_inspect_mod…

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ graph LR
         - [pg_onnx_import_model(TEXT, TEXT, BYTEA, JSONB, TEXT)](https://github.com/kibae/pg_onnx/wiki/Functions#pg_onnx_import_modeltext-text-bytea-jsonb-text)
         - [pg_onnx_drop_model(TEXT, TEXT)](https://github.com/kibae/pg_onnx/wiki/Functions#pg_onnx_drop_modeltext-text)
         - [pg_onnx_list_model()](https://github.com/kibae/pg_onnx/wiki/Functions#pg_onnx_list_model)
-        - [pg_onnx_inspect_model_bin(BYTEA)](https://github.com/kibae/pg_onnx/wiki/Functions#pg_onnx_inspect_model_binbytea)
+        - [pg_onnx_inspect_model_bin(BYTEA, JSONB)](https://github.com/kibae/pg_onnx/wiki/Functions#pg_onnx_inspect_model_bin-bytea-jsonb)
     - [ONNX Session Functions](https://github.com/kibae/pg_onnx/wiki/Functions#onnx-session-functions)
         - [pg_onnx_create_session(TEXT, TEXT)](https://github.com/kibae/pg_onnx/wiki/Functions#pg_onnx_create_sessiontext-text)
         - [pg_onnx_describe_session(TEXT, TEXT)](https://github.com/kibae/pg_onnx/wiki/Functions#pg_onnx_describe_sessiontext-text)
@@ -158,7 +158,7 @@ sudo cmake --install build/pg_onnx
     - [pg_onnx_import_model(TEXT, TEXT, BYTEA, JSONB, TEXT)](https://github.com/kibae/pg_onnx/wiki/Functions#pg_onnx_import_modeltext-text-bytea-jsonb-text)
     - [pg_onnx_drop_model(TEXT, TEXT)](https://github.com/kibae/pg_onnx/wiki/Functions#pg_onnx_drop_modeltext-text)
     - [pg_onnx_list_model()](https://github.com/kibae/pg_onnx/wiki/Functions#pg_onnx_list_model)
-    - [pg_onnx_inspect_model_bin(BYTEA)](https://github.com/kibae/pg_onnx/wiki/Functions#pg_onnx_inspect_model_binbytea)
+    - [pg_onnx_inspect_model_bin(BYTEA, JSONB)](https://github.com/kibae/pg_onnx/wiki/Functions#pg_onnx_inspect_model_bin-bytea-jsonb)
 - [ONNX Session Functions](https://github.com/kibae/pg_onnx/wiki/Functions#onnx-session-functions)
     - [pg_onnx_create_session(TEXT, TEXT)](https://github.com/kibae/pg_onnx/wiki/Functions#pg_onnx_create_sessiontext-text)
     - [pg_onnx_describe_session(TEXT, TEXT)](https://github.com/kibae/pg_onnx/wiki/Functions#pg_onnx_describe_sessiontext-text)
@@ -258,5 +258,17 @@ CREATE TRIGGER trigger_test_insert
     ON trigger_test
     FOR EACH ROW
     EXECUTE PROCEDURE trigger_test_insert();
-```
 
+## ORT Extensions Support (onnxruntime-extensions)
+
+If your model relies on custom ops provided by onnxruntime-extensions, you can load the extension library by passing `ortextensions_path` in the options when importing the model.
+
+```sql
+SELECT pg_onnx_import_model(
+    'e5-tok',
+    'v1',
+    PG_READ_BINARY_FILE('/PATH/tokenizer.onnx')::bytea,
+    '{"ortextensions_path": "libortextensions.so"}'::jsonb,
+    'e5 tokenizer'
+);
+```

--- a/docs/functions.md
+++ b/docs/functions.md
@@ -4,7 +4,7 @@
     - [pg_onnx_import_model(TEXT, TEXT, BYTEA, JSONB, TEXT)](#pg_onnx_import_modeltext-text-bytea-jsonb-text)
     - [pg_onnx_drop_model(TEXT, TEXT)](#pg_onnx_drop_modeltext-text)
     - [pg_onnx_list_model()](#pg_onnx_list_model)
-    - [pg_onnx_inspect_model_bin(BYTEA)](#pg_onnx_inspect_model_binbytea)
+    - [pg_onnx_inspect_model_bin(BYTEA, JSONB)](#pg_onnx_inspect_model_bin-bytea-jsonb)
 - [ONNX Session Functions](#onnx-session-functions)
     - [pg_onnx_create_session(TEXT, TEXT)](#pg_onnx_create_sessiontext-text)
     - [pg_onnx_describe_session(TEXT, TEXT)](#pg_onnx_describe_sessiontext-text)
@@ -96,12 +96,14 @@ FROM pg_onnx_list_model();
 
 ----
 
-### pg_onnx_inspect_model_bin(BYTEA)
+### pg_onnx_inspect_model_bin(BYTEA, JSONB)
 
 - Get the type and shape information of the inputs and outputs of the ONNX file.
 - Returns
     - `inputs(JSONB)`: Input type and shape
     - `outputs(JSONB)`: Output type and shape
+- The second argument `option(JSONB)` is optional.
+- If your model relies on custom ops provided by onnxruntime-extensions, you can load the extension library by passing `ortextensions_path` in the options when importing the model. (e.g., ``'{"ortextensions_path": "libortextensions.so"}'::jsonb``)
 
 ```sql
 SELECT *

--- a/pg_onnx/pg_onnx--1.2.1.sql
+++ b/pg_onnx/pg_onnx--1.2.1.sql
@@ -19,7 +19,7 @@ CREATE TYPE pg_onnx_inspect AS
     outputs jsonb
 );
 
-CREATE FUNCTION pg_onnx_inspect_model_bin(model bytea)
+CREATE FUNCTION pg_onnx_inspect_model_bin(model bytea, option jsonb DEFAULT '{}'::JSONB)
     RETURNS pg_onnx_inspect
 AS
 'MODULE_PATHNAME',
@@ -48,7 +48,7 @@ DECLARE
     result    BOOLEAN;
     inspect   pg_onnx_inspect;
 BEGIN
-    inspect := pg_onnx_inspect_model_bin($3);
+    inspect := pg_onnx_inspect_model_bin($3, $4);
     model_oid := lo_from_bytea(0, $3);
 
     -- RAISE NOTICE 'model_oid: %', model_oid;

--- a/pg_onnx/pg_onnx.cpp
+++ b/pg_onnx/pg_onnx.cpp
@@ -12,7 +12,7 @@ PG_FUNCTION_INFO_V1(pg_onnx_internal_destroy_session);
 PG_FUNCTION_INFO_V1(pg_onnx_internal_execute_session);
 
 Datum pg_onnx_inspect_model_bin(PG_FUNCTION_ARGS) {
-	if (PG_NARGS() != 1 || PG_ARGISNULL(0))
+	if (PG_NARGS() < 1 || PG_ARGISNULL(0))
 		ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE), errmsg("invalid argument")));
 
 	TupleDesc tuple_desc;
@@ -27,11 +27,17 @@ Datum pg_onnx_inspect_model_bin(PG_FUNCTION_ARGS) {
 		);
 
 	try {
-		// args: model BYTEA
+		// args: model BYTEA, option JSONB (optional)
 		auto model_datum = PG_GETARG_DATUM(0);
 		auto model_data = DatumGetByteaPP(model_datum);
+		json option = json::object();
+		if (PG_NARGS() >= 2 && !PG_ARGISNULL(1)) {
+			Jsonb *option_jsonb = PG_GETARG_JSONB_P(1);
+			auto option_cstr = JsonbToCString(nullptr, &option_jsonb->root, VARSIZE_ANY_EXHDR(option_jsonb));
+			option = json::parse(option_cstr);
+		}
 		Orts::onnx::session session(
-			Orts::onnx::session_key("__tmp", "__tmp"), VARDATA_ANY(model_data), VARSIZE_ANY_EXHDR(model_data)
+			Orts::onnx::session_key("__tmp", "__tmp"), VARDATA_ANY(model_data), VARSIZE_ANY_EXHDR(model_data), option
 		);
 		auto session_info = session.to_json();
 


### PR DESCRIPTION
## Summary
This PR adds support for passing the `ortextensions_path` option to `pg_onnx_inspect_model_bin`, enabling dynamic loading of onnxruntime-extensions during model inspection and registration.

## Motivation
Following [onnxruntime-server#101](https://github.com/kibae/onnxruntime-server/pull/101), which introduced support for runtime inference with onnxruntime-extensions, this patch brings similar flexibility to pg_onnx. By enabling onnxruntime-extensions during inspection, we can support models that rely on custom ops such as tokenizers, improving compatibility and enabling more robust end-to-end workflows.
